### PR TITLE
fix node picking

### DIFF
--- a/src/director_digiforest/forestpayloadspanel.py
+++ b/src/director_digiforest/forestpayloadspanel.py
@@ -56,6 +56,7 @@ class ForestPayloadsPanel(QObject):
 
         self.widget = loader.load(uifile)
         self.file_data = np.array([])
+        self.exp_num = 0
         self.view = app.getDRCView()
         self.ui = WidgetDict(self.widget.children())
         
@@ -376,18 +377,20 @@ class ForestPayloadsPanel(QObject):
         vis.showPolyData(cloud_pd, name, visible=visible, parent=parent)
 
     def _start_node_picking(self, ):
-        picker = ObjectPicker(numberOfPoints=1, view=app.getCurrentRenderView())
+        object_list = [name + str(i) for i in range(1, self.exp_num+1) for name in ("payload_", "experiment_")]
+
+        picker = ObjectPicker(number_of_points=1, view=app.getCurrentRenderView(), object_list=object_list)
         segmentation.addViewPicker(picker)
         picker.enabled = True
         picker.start()
-        picker.annotationFunc = functools.partial(self.find_node_data)
+        picker.annotation_func = functools.partial(self.find_node_data)
 
     def _start_tree_picking(self, ):
-        picker = ObjectPicker(numberOfPoints=1, view=app.getCurrentRenderView(), pickType="cells")
+        picker = ObjectPicker(number_of_points=1, view=app.getCurrentRenderView(), pick_type="cells")
         segmentation.addViewPicker(picker)
         picker.enabled = True
         picker.start()
-        picker.annotationFunc = functools.partial(self.find_tree)
+        picker.annotation_func = functools.partial(self.find_tree)
 
     def _stop_node_picking(self):
         pass
@@ -465,6 +468,7 @@ class ForestPayloadsPanel(QObject):
         for row in self.file_data:
             # assumes that an experiment has less than 10000 elements
             if row[0] > exp_num*10000 or index_row == self.file_data.shape[0]:
+                self.exp_num += 1
                 # draw the trajectory
                 self._draw_line(data, "slam")
                 # drawing the pose graph

--- a/src/director_digiforest/objectpicker.py
+++ b/src/director_digiforest/objectpicker.py
@@ -5,30 +5,30 @@ from director.debugpolydata import DebugData
 from PythonQt import QtCore, QtGui, QtUiTools
 
 class ObjectPicker(TimerCallback):
-    def __init__(self, view, pickType="points", numberOfPoints=3):
+    def __init__(self, view, pick_type="points", number_of_points=3, object_list=None):
         TimerCallback.__init__(self)
         self.targetFps = 30
         self.enabled = False
-        self.pickType = pickType
-        self.numberOfPoints = numberOfPoints
-        self.annotationObj = None
-        self.drawLines = True
+        self.pick_type = pick_type
+        self.number_of_points = number_of_points
+        self.annotation_obj = None
+        self.object_list = object_list
         self.view = view
         self.clear()
 
     def clear(self):
-        self.points = [None for i in range(self.numberOfPoints)]
-        self.hoverPos = None
-        self.annotationFunc = None
-        self.lastMovePos = [0, 0]
+        self.points = [None for i in range(self.number_of_points)]
+        self.hover_pos = None
+        self.annotation_func = None
+        self.last_move_pos = [0, 0]
 
     def onMouseMove(self, displayPoint, modifiers=None):
-        self.lastMovePos = displayPoint
+        self.last_move_pos = displayPoint
 
     def onMousePress(self, displayPoint, modifiers=None):
-        for i in range(self.numberOfPoints):
+        for i in range(self.number_of_points):
             if self.points[i] is None:
-                self.points[i] = self.hoverPos
+                self.points[i] = self.hover_pos
                 break
 
         if self.points[-1] is not None:
@@ -37,11 +37,11 @@ class ObjectPicker(TimerCallback):
     def finish(self):
 
         self.enabled = False
-        om.removeFromObjectModel(self.annotationObj)
+        om.removeFromObjectModel(self.annotation_obj)
 
         points = [p.copy() for p in self.points]
-        if self.annotationFunc is not None:
-            self.annotationFunc(*points)
+        if self.annotation_func is not None:
+            self.annotation_func(*points)
 
     def handleRelease(self, displayPoint):
         pass
@@ -50,25 +50,35 @@ class ObjectPicker(TimerCallback):
 
         d = DebugData()
 
-        points = [p if p is not None else self.hoverPos for p in self.points]
+        points = [p if p is not None else self.hover_pos for p in self.points]
 
         # draw points
         for p in points:
             if p is not None:
                 d.addSphere(p, radius=0.08)
 
-        self.annotationObj = vis.updatePolyData(
+        self.annotation_obj = vis.updatePolyData(
             d.getPolyData(), "annotation", parent=om.findObjectByName("slam")
         )
-        self.annotationObj.setProperty("Color", QtGui.QColor(0, 255, 0))
-        self.annotationObj.actor.SetPickable(False)
+        self.annotation_obj.setProperty("Color", QtGui.QColor(0, 255, 0))
+        self.annotation_obj.actor.SetPickable(False)
 
     def tick(self):
         if not self.enabled:
             return
 
-        pickedPointFields = vis.pickPoint(
-            self.lastMovePos, self.view, pickType=self.pickType
-        )
-        self.hoverPos = pickedPointFields.pickedPoint
-        self.draw()
+        if self.object_list is not None:
+            for object_name in self.object_list:
+                picked_point_fields = vis.pickPoint(
+                    self.last_move_pos, self.view, pickType=self.pick_type, obj=object_name
+                )
+                if picked_point_fields.pickedDataset is not None:
+                    self.hover_pos = picked_point_fields.pickedPoint
+                    self.draw()
+                    return
+        else:
+            picked_point_fields = vis.pickPoint(
+                self.last_move_pos, self.view, pickType=self.pick_type
+            )
+            self.hover_pos = picked_point_fields.pickedPoint
+            self.draw()


### PR DESCRIPTION
Points of point clouds could disrupt the payload picking selection. The point picker now only consider the "node objects" as candidates, all the other objects are ignored.